### PR TITLE
Minor fix in module statement in runner_list.pl

### DIFF
--- a/runner_list.pl
+++ b/runner_list.pl
@@ -1,4 +1,4 @@
-:- module(runner_list, [list_go]).
+:- module(runner_list, [list_go/0]).
 
 run_koan(X,L) :-
 	koan_helper(X, about_lists:L).


### PR DESCRIPTION
There was a warning about the module statement. Adding the arity "0" fixes it.